### PR TITLE
Fix for install on every puppet run and install from package manager

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class kong::install {
 
       if $kong::package_provider != 'apple' {
         $_package_ensure = latest
-      } else {    
+      } else {
         $_package_ensure = present
       }
       

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,7 +32,7 @@ class kong::install {
       } else {
         $_package_ensure = present
       }
-      
+
       package { 'kong':
         ensure   => $_package_ensure,
         provider => $kong::package_provider,
@@ -44,7 +44,7 @@ class kong::install {
       package { 'kong':
         ensure => $kong::version,
       }
-    }    
+    }
 
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,24 +28,21 @@ class kong::install {
       # package provider feature but only rpm supports versionable
 
       if $kong::package_provider != 'apple' {
-        package { 'kong':
-          ensure   => latest,
-          provider => $kong::package_provider,
-          source   => "${kong::staging_dir}/kong-${kong::version}.${kong::package_suffix}",
-        }
-      } else {
-        package { 'kong':
-          ensure   => present,
-          provider => $kong::package_provider,
-          source   => "${kong::staging_dir}/kong-${kong::version}.${kong::package_suffix}",
-        }
+        $_package_ensure = latest
+      } else {    
+        $_package_ensure = present
+      }
+      
+      package { 'kong':
+        ensure   => $_package_ensure,
+        provider => $kong::package_provider,
+        source   => "${kong::staging_dir}/kong-${kong::version}.${kong::package_suffix}",
       }
 
     }
 
     # Install package from your local repository using the native package provider
     package { 'kong:':
-      name   => 'kong',
       ensure => $kong::version,
     }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,7 +44,7 @@ class kong::install {
     }
 
     # Install package from your local repository using the native package provider
-    package { 'kong:':
+    package { 'kong':
       ensure => $kong::version,
     }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,12 +39,12 @@ class kong::install {
         source   => "${kong::staging_dir}/kong-${kong::version}.${kong::package_suffix}",
       }
 
-    }
-
-    # Install package from your local repository using the native package provider
-    package { 'kong:':
-      ensure => $kong::version,
-    }
+    } else {
+      # Install package from your local repository using the native package provider
+      package { 'kong:':
+        ensure => $kong::version,
+      }
+    }    
 
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,7 +44,8 @@ class kong::install {
     }
 
     # Install package from your local repository using the native package provider
-    package { 'kong':
+    package { 'kong:':
+      name   => 'kong',
       ensure => $kong::version,
     }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,7 +41,7 @@ class kong::install {
 
     } else {
       # Install package from your local repository using the native package provider
-      package { 'kong:':
+      package { 'kong':
         ensure => $kong::version,
       }
     }    


### PR DESCRIPTION
There was a bug resulting in the module trying to install kong on every puppet run and it caused that if $kong::manage_package_fetch was not set to true the package would not be installed from the package manager which I suspect should be the expected behaviour.
